### PR TITLE
Use direct SchemaModel import for schemas

### DIFF
--- a/src/data/schemas.py
+++ b/src/data/schemas.py
@@ -1,0 +1,14 @@
+from pandera import SchemaModel
+from pandera.typing import Series
+
+
+class AxisSchema(SchemaModel):
+    """Schema for axis data."""
+    x: Series[int]
+    y: Series[int]
+
+
+class MeasuresSchema(SchemaModel):
+    """Schema for measurement data."""
+    length: Series[float]
+    width: Series[float]


### PR DESCRIPTION
## Summary
- import `SchemaModel` directly from `pandera`
- inherit `AxisSchema` and `MeasuresSchema` from `SchemaModel`

## Testing
- `mypy src/data/schemas.py` *(fails: Cannot find implementation or library stub for module named "pandera" [import-not-found])*

------
https://chatgpt.com/codex/tasks/task_e_68b1580e49dc832eacdc0fba7b4972a6